### PR TITLE
Enhance class matching to accept space-separated list or array

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function parse(selector, options) {
     }
 
     crnt.push(
+        token.type === 'class' ? listContains(token.type, token.data) :
         token.type === 'attr' ? attr(token) :
         token.type === ':' || token.type === '::' ? pseudo(token) :
         token.type === '*' ? Boolean :
@@ -157,6 +158,17 @@ function parse(selector, options) {
       }
 
       return true
+    }
+  }
+
+  function listContains(type, data) {
+    return function(node) {
+      var val = options[type](node)
+      val =
+        Array.isArray(val) ? val :
+        val ? val.toString().split(/\s+/) :
+        []
+      return val.indexOf(data) >= 0
     }
   }
 
@@ -269,7 +281,7 @@ function valid_not_match(options, selector) {
   var fn = parse(selector, options)
 
   return not_function
-  
+
   function not_function(node) {
     return !fn(node, true)
   }

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ language = cssauron({
 })
 
 test('select single', test_select_single)
+test('select classlist', test_select_classlist)
 test('select multiple', test_select_multiple)
 test('select subject', test_select_subject)
 
@@ -28,12 +29,30 @@ function test_select_single(assert) {
   assert.end()
 }
 
+function test_select_classlist(assert) {
+  var data =  [
+    { class: 'a-class   b-class  c-class ' },
+    { class: ['a-class', 'b-class', 'c-class'] }
+  ]
+
+  data.forEach(function(data) {
+    assert.ok(language('.a-class')(data))
+    assert.ok(language('.b-class')(data))
+    assert.ok(language('.c-class')(data))
+    assert.ok(!language('.one-other-class')(data))
+  })
+
+  assert.ok(!language('.whatever')({class: null}))
+
+  assert.end()
+}
+
 function test_select_multiple(assert) {
   var data = {id: 'one-id', class: 'one-class', tag: 'one-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[]}
     , data2 = {id: 'two-id', class: 'two-class', tag: 'two-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[]}
     , data3 = {id: 'three-id', class: 'three-class', tag: 'three-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[]}
-    , parent = {id: 'parent-id', class: 'parent-class', tag: 'parent-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[data, data2, data3]} 
-    , root = {id: 'root-id', class: 'root-class', tag: 'root-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[parent]} 
+    , parent = {id: 'parent-id', class: 'parent-class', tag: 'parent-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[data, data2, data3]}
+    , root = {id: 'root-id', class: 'root-class', tag: 'root-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[parent]}
 
   data.parent = parent
   data2.parent = parent
@@ -95,8 +114,8 @@ function test_select_subject(assert) {
   var data = {id: 'one-id', class: 'one-class', tag: 'one-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[]}
     , data2 = {id: 'two-id', class: 'two-class', tag: 'two-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[]}
     , data3 = {id: 'three-id', class: 'three-class', tag: 'three-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[]}
-    , parent = {id: 'parent-id', class: 'parent-class', tag: 'parent-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[data, data2, data3]} 
-    , root = {id: 'root-id', class: 'root-class', tag: 'root-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[parent]} 
+    , parent = {id: 'parent-id', class: 'parent-class', tag: 'parent-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[data, data2, data3]}
+    , root = {id: 'root-id', class: 'root-class', tag: 'root-tag', attr:{first: 'test', second:'gary busey', third:'richard-m-nixon'}, parent:null, children:[parent]}
     , res
 
   data.parent = parent


### PR DESCRIPTION
Previously class matching was happening by simple equality checking. This update allows `options.class` to be (or return) either a space-separated string or an array of strings. Also adds a test for both of these.
