### PR TITLE
change "through: "X.X.X" to "through: "^2.3.8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Chris Dickinson <chris@neversaw.us>",
   "license": "MIT",
   "dependencies": {
-    "through": "X.X.X"
+    "through": "^2.3.8"
   },
   "devDependencies": {
     "tape": "~2.0.0"


### PR DESCRIPTION
Greetings Chris! 👋👋

I'm proposing this pull request because I've run into a bit of an issue.  If this PR isn't the correct way to solve that, let me know, and I'll look towards other avenues.

I've made a [boilerplate codebase](https://github.com/dsurgeons/ds-node-boilerplate), and it uses [trumpet](https://github.com/substack/node-trumpet).  Trumpet depends on [html-select](https://github.com/substack/html-select), which depends on cssauron.

It seems that with npm 3.10.x, if you run `npm install` in the [boilerplate codebase](https://github.com/dsurgeons/ds-node-boilerplate) after pulling it down, an old version of `through` gets installed since the only other package that uses `through` that I'm using is [oppressor](https://github.com/substack/oppressor/blob/master/package.json#L11).  This old version of `through` crashes the server.

Two things seem to fix it so far:

The first is that I've included `through` in the package.json for the [boilerplate codebase](https://github.com/dsurgeons/ds-node-boilerplate).  I'd rather not include `through` in the package.json since I never directly call or use it, but that seems to be the only fix for now.

The second way that seems to fix the issue is by giving `through` a version number in the package.json of cssauron.  I'll be honest; I'm not entirely sure of what X.X.X does in the version field, so if this PR doesn't seem right to you, please let me know :)

Thanks for your time with making this module!

steps to reproduce my issue:
1. use npm3 `npm i npm@lastest -g`
2. git clone https://github.com/dsurgeons/ds-node-boilerplate
3. remove `through` from the package.json (not `through2`)
4. npm install
5. npm run dev
6. go to localhost:9090
7. server crashes
8. error is: 

```
/Users/Jake/playgrounds/debug/node2/node_modules/cssauron/tokenizer.js:69
      stream.queue(token())
             ^

TypeError: stream.queue is not a function
    at Stream.onend (/Users/Jake/playgrounds/debug/node2/node_modules/cssauron/tokenizer.js:69:14)
    at Stream.stream.end (/Users/Jake/playgrounds/debug/node2/node_modules/through/index.js:43:9)
    at parse (/Users/Jake/playgrounds/debug/node2/node_modules/cssauron/index.js:45:6)
    at Plex._lang (/Users/Jake/playgrounds/debug/node2/node_modules/cssauron/index.js:7:12)
    at Plex.select (/Users/Jake/playgrounds/debug/node2/node_modules/html-select/index.js:82:39)
    at Trumpet._selectAll (/Users/Jake/playgrounds/debug/node2/node_modules/trumpet/index.js:97:18)
    at Trumpet.select (/Users/Jake/playgrounds/debug/node2/node_modules/trumpet/index.js:64:20)
    at /Users/Jake/playgrounds/debug/node2/index.js:202:27
    at Server.http.createServer (/Users/Jake/playgrounds/debug/node2/index.js:102:5)
    at emitTwo (events.js:106:13)
```
